### PR TITLE
CORE-828: Fix null address crash

### DIFF
--- a/WalletKitCore/hedera/BRHederaAccount.c
+++ b/WalletKitCore/hedera/BRHederaAccount.c
@@ -99,7 +99,7 @@ extern uint8_t *hederaAccountGetSerialization (BRHederaAccount account, size_t *
     assert (NULL != account);
 
     // Get the sizes of what we are storing and allocate storage
-    uint8_t addressBuffer[HEDERA_ADDRESS_SERIALIZED_SIZE] = {0}
+    uint8_t addressBuffer[HEDERA_ADDRESS_SERIALIZED_SIZE] = {0};
     // If we have an address then serialize it - otherwise we just copy 0's to the stream
     if (NULL != account->address) {
         hederaAddressSerialize (account->address, addressBuffer, HEDERA_ADDRESS_SERIALIZED_SIZE);

--- a/WalletKitCore/hedera/BRHederaAccount.c
+++ b/WalletKitCore/hedera/BRHederaAccount.c
@@ -99,8 +99,11 @@ extern uint8_t *hederaAccountGetSerialization (BRHederaAccount account, size_t *
     assert (NULL != account);
 
     // Get the sizes of what we are storing and allocate storage
-    uint8_t addressBuffer[HEDERA_ADDRESS_SERIALIZED_SIZE];
-    hederaAddressSerialize (account->address, addressBuffer, HEDERA_ADDRESS_SERIALIZED_SIZE);
+    uint8_t addressBuffer[HEDERA_ADDRESS_SERIALIZED_SIZE] = {0}
+    // If we have an address then serialize it - otherwise we just copy 0's to the stream
+    if (NULL != account->address) {
+        hederaAddressSerialize (account->address, addressBuffer, HEDERA_ADDRESS_SERIALIZED_SIZE);
+    }
     *bytesCount = HEDERA_ADDRESS_SERIALIZED_SIZE + HEDERA_PUBLIC_KEY_SIZE;
     uint8_t *bytes = calloc (1, *bytesCount);
 


### PR DESCRIPTION
With Hedera when we create a brand new account we have the public key
but we cannot generate an account ID (BRHederaAddress). So it will be
NULL until someone sets the address.