### PR TITLE
CORE-844: Add 9 more hedera nodes to the wallet

### DIFF
--- a/WalletKitCore/hedera/BRHederaWallet.c
+++ b/WalletKitCore/hedera/BRHederaWallet.c
@@ -39,17 +39,11 @@ hederaWalletCreate (BRHederaAccount account)
      "0.0.13":"35.234.132.107:50211", "0.0.14": "34.94.67.202:50211",
      "0.0.15":"35.236.2.27:50211"}
      */
-    array_new(wallet->nodes, 10);
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.3"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.4"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.5"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.6"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.7"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.8"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.9"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.10"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.11"));
-    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.12"));
+    array_new(wallet->nodes, HEDERA_NODE_COUNT);
+    int64_t hedera_node_start = HEDERA_NODE_START;
+    for (int i = HEDERA_NODE_START; i < (HEDERA_NODE_COUNT + HEDERA_NODE_START); i++) {
+        array_add(wallet->nodes, hederaAddressCreate(0, 0, i));
+    }
 
     array_new(wallet->transactions, 0);
 
@@ -110,7 +104,7 @@ hederaWalletGetNodeAddress(BRHederaWallet wallet)
 {
     static unsigned index = 0;
     assert(wallet);
-    if (index > 9) {
+    if (index > HEDERA_NODE_COUNT - 1) {
         index = 0;
     }
     BRHederaAddress node = wallet->nodes[index++];

--- a/WalletKitCore/hedera/BRHederaWallet.c
+++ b/WalletKitCore/hedera/BRHederaWallet.c
@@ -30,8 +30,26 @@ hederaWalletCreate (BRHederaAccount account)
     wallet->account = account;
     // TODO - do we just hard code Hedera nodes here - we probably can for now
     // but perhaps in the future there will be additional shards/realms
+    /*
+     {"0.0.3":"104.196.1.78:50211", "0.0.4": "35.245.250.134:50211",
+     "0.0.5":"34.68.209.35:50211", "0.0.6": "34.82.173.33:50211",
+     "0.0.7":"35.200.105.230:50211", "0.0.8": "35.203.87.206:50211",
+     "0.0.9":"35.189.221.159:50211", "0.0.10": "35.234.104.86:50211",
+     "0.0.11":"34.90.238.202:50211", "0.0.12": "35.228.11.53:50211",
+     "0.0.13":"35.234.132.107:50211", "0.0.14": "34.94.67.202:50211",
+     "0.0.15":"35.236.2.27:50211"}
+     */
     array_new(wallet->nodes, 10);
     array_add(wallet->nodes, hederaAddressCreateFromString("0.0.3"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.4"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.5"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.6"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.7"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.8"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.9"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.10"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.11"));
+    array_add(wallet->nodes, hederaAddressCreateFromString("0.0.12"));
 
     array_new(wallet->transactions, 0);
 
@@ -90,8 +108,12 @@ hederaWalletGetBalance (BRHederaWallet wallet)
 extern BRHederaAddress
 hederaWalletGetNodeAddress(BRHederaWallet wallet)
 {
+    static unsigned index = 0;
     assert(wallet);
-    BRHederaAddress node = wallet->nodes[0];
+    if (index > 9) {
+        index = 0;
+    }
+    BRHederaAddress node = wallet->nodes[index++];
     return hederaAddressClone(node);
 }
 

--- a/WalletKitCore/hedera/BRHederaWallet.h
+++ b/WalletKitCore/hedera/BRHederaWallet.h
@@ -20,6 +20,8 @@
 extern "C" {
 #endif
 
+#define HEDERA_NODE_COUNT 10
+#define HEDERA_NODE_START 3
 
 typedef struct BRHederaWalletRecord *BRHederaWallet;
 

--- a/WalletKitCoreTests/test/hedera/testHedera.c
+++ b/WalletKitCoreTests/test/hedera/testHedera.c
@@ -524,10 +524,28 @@ static void account_tests() {
     accountStringTest("patient");
 }
 
+static void nodeAddressTest()
+{
+    // Create a wallet
+    BRHederaAccount account = getAccount ("patient"); // Our wallet account
+    BRHederaWallet wallet = hederaWalletCreate (account);
+    for ( int i = 3; i <= 12; i++ ) {
+        // Get the first 10 nodes
+        BRHederaAddress address = hederaWalletGetNodeAddress(wallet);
+        assert(hederaAddressGetAccount(address) == i);
+        hederaAddressFree(address);
+    }
+    // Now get another one and see if we go back to the beginning
+    BRHederaAddress address = hederaWalletGetNodeAddress(wallet);
+    assert(hederaAddressGetAccount(address) == 3);
+    hederaAddressFree(address);
+}
+
 static void wallet_tests()
 {
     createAndDeleteWallet();
     walletBalanceTests();
+    nodeAddressTest();
 }
 
 static void transaction_tests() {

--- a/WalletKitCoreTests/test/hedera/testHedera.c
+++ b/WalletKitCoreTests/test/hedera/testHedera.c
@@ -529,15 +529,17 @@ static void nodeAddressTest()
     // Create a wallet
     BRHederaAccount account = getAccount ("patient"); // Our wallet account
     BRHederaWallet wallet = hederaWalletCreate (account);
-    for ( int i = 3; i <= 12; i++ ) {
+    for ( int i = HEDERA_NODE_START; i <= HEDERA_NODE_COUNT + HEDERA_NODE_START - 1; i++ ) {
         // Get the first 10 nodes
         BRHederaAddress address = hederaWalletGetNodeAddress(wallet);
         assert(hederaAddressGetAccount(address) == i);
+        assert(hederaAddressGetShard(address) == 0);
+        assert(hederaAddressGetRealm(address) == 0);
         hederaAddressFree(address);
     }
     // Now get another one and see if we go back to the beginning
     BRHederaAddress address = hederaWalletGetNodeAddress(wallet);
-    assert(hederaAddressGetAccount(address) == 3);
+    assert(hederaAddressGetAccount(address) == HEDERA_NODE_START);
     hederaAddressFree(address);
 }
 


### PR DESCRIPTION
When encrypting a transaction use a round robin approach to which
node to use.

NOTE: Even though the unit tests are not enabled in this branch - I did cherry-pick this to a local copy of CORE-845 and ensure the unit test did pass and the correct 10 nodes are returned when calling hederaWalletGetNodeAddress