### PR TITLE
CORE-843: Add a `strict` argument to `rippleAddressCreateFromString()`

### DIFF
--- a/WalletKitCore/generic/BRGenericRipple.c
+++ b/WalletKitCore/generic/BRGenericRipple.c
@@ -96,7 +96,7 @@ genericRippleAccountSignTransferWithKey (BRGenericAccountRef account,
 
 static BRGenericAddressRef
 genericRippleAddressCreate (const char *string) {
-    return (BRGenericAddressRef) rippleAddressCreateFromString (string);
+    return (BRGenericAddressRef) rippleAddressCreateFromString (string, true);
 }
 
 static char *
@@ -411,8 +411,8 @@ genericRippleWalletManagerRecoverTransfer (const char *hash,
     BRRippleUnitDrops amountDrops, feeDrops = 0;
     sscanf(amount, "%" PRIu64, &amountDrops);
     if (NULL != fee) sscanf(fee, "%" PRIu64, &feeDrops);
-    BRRippleAddress toAddress   = rippleAddressCreateFromString(to);
-    BRRippleAddress fromAddress = rippleAddressCreateFromString(from);
+    BRRippleAddress toAddress   = rippleAddressCreateFromString (to,   false);
+    BRRippleAddress fromAddress = rippleAddressCreateFromString (from, false);
     // Convert the hash string to bytes
     BRRippleTransactionHash txId;
     hexDecode(txId.bytes, sizeof(txId.bytes), hash, strlen(hash));

--- a/WalletKitCore/ripple/BRRippleAddress.c
+++ b/WalletKitCore/ripple/BRRippleAddress.c
@@ -179,15 +179,32 @@ BRRippleAddress rippleAddressStringToAddress(const char* input)
 }
 
 extern BRRippleAddress
-rippleAddressCreateFromString(const char * rippleAddressString)
+rippleAddressCreateFromString(const char * rippleAddressString, bool strict)
 {
-    // 2 special case so far - the __fee__ address and "unknown" address
-    // See the note in BRRippleAcount.h with respect to the feeAddressBytes
-    if (rippleAddressString == NULL || strlen(rippleAddressString) == 0 || strcmp(rippleAddressString, "unknown") == 0) {
+    // Handle an 'invalid' string argument.
+    if (rippleAddressString == NULL || strlen(rippleAddressString) == 0) {
+        return (strict
+                ? NULL
+                : rippleAddressCreateUnknownAddress ());
+    }
+
+    //  If strict, only accept 'r...' addresses
+    else if (strict) {
+        return rippleAddressStringToAddress (rippleAddressString);
+    }
+
+    // Handle an 'unknown' address
+    else if (strcmp(rippleAddressString, "unknown") == 0) {
         return rippleAddressCreateUnknownAddress ();
-    } else if (strcmp(rippleAddressString, "__fee__") == 0) {
+    }
+
+    // Handle a '__fee__' address
+    else if (strcmp(rippleAddressString, "__fee__") == 0) {
         return rippleAddressCreateFeeAddress ();
-    } else {
+    }
+
+    // Handle an 'r...' address (in a non-strict mode).
+    else {
         // Work backwards from this ripple address (string) to what is
         // known as the acount ID (20 bytes)
         return rippleAddressStringToAddress (rippleAddressString);

--- a/WalletKitCore/ripple/BRRippleAddress.h
+++ b/WalletKitCore/ripple/BRRippleAddress.h
@@ -11,6 +11,7 @@
 #ifndef BRRippleAddress_h
 #define BRRippleAddress_h
 
+#include <stdbool.h>
 #include "support/BRKey.h"
 
 #ifdef __cplusplus
@@ -43,11 +44,13 @@ rippleAddressCreateFromKey (BRKey *publicKey);
  * Create a ripple address from a valid ripple address string
  *
  * @param address   - ripple address string in the "r..." format
+ * @param strict    - only accept 'r...' format addresses; otherwise: "__fee__" and "unknown" are
+ *    permitted.  These other addresses are used internally.
  *
  * @return address  - a BRRippleAddress object
  */
 extern BRRippleAddress
-rippleAddressCreateFromString(const char * rippleAddressString);
+rippleAddressCreateFromString(const char * rippleAddressString, bool strict);
 
 /**
  * Create a ripple address from the raw bytes (20 for ripple)

--- a/WalletKitCoreTests/test/ripple/testRipple.c
+++ b/WalletKitCoreTests/test/ripple/testRipple.c
@@ -648,7 +648,7 @@ static void testRippleAddressCreate()
         0xD0, 0x1F, 0x30, 0x4E, 0xC8, 0x29, 0x51, 0xE3, 0x7C, 0xA2 };
     const char* ripple_address = "r41vZ8exoVyUfVzs56yeN8xB5gDhSkho9a";
     
-    BRRippleAddress address = rippleAddressCreateFromString(ripple_address);
+    BRRippleAddress address = rippleAddressCreateFromString(ripple_address, true);
     BRRippleAddress expectedAddress = rippleAddressCreateFromBytes(expected_bytes, 20);
     assert(1 == rippleAddressEqual(address, expectedAddress));
     rippleAddressFree(address);
@@ -735,7 +735,7 @@ testTransactionId (void /* ... */) {
 }
 
 void testRippleAddressUnknown() {
-    BRRippleAddress address = rippleAddressCreateFromString("unknown");
+    BRRippleAddress address = rippleAddressCreateFromString("unknown", false);
     assert(address);
 
     char * addressString = rippleAddressAsString(address);
@@ -745,8 +745,14 @@ void testRippleAddressUnknown() {
     rippleAddressFree(address);
 }
 
+void testRippleAddressUnknownStrict() {
+    BRRippleAddress address = rippleAddressCreateFromString("unknown", true);
+    assert(NULL == address);
+}
+
+
 void testRippleAddressInvalid() {
-    BRRippleAddress address = rippleAddressCreateFromString(""); // Empty string
+    BRRippleAddress address = rippleAddressCreateFromString("", false); // Empty string
     assert(address);
 
     char * addressString = rippleAddressAsString(address);
@@ -757,7 +763,7 @@ void testRippleAddressInvalid() {
 }
 
 void testRippleAddressFee() {
-    BRRippleAddress address = rippleAddressCreateFromString("__fee__"); // Empty string
+    BRRippleAddress address = rippleAddressCreateFromString("__fee__", false); // Empty string
     assert(address);
 
     char * addressString = rippleAddressAsString(address);
@@ -776,6 +782,7 @@ void rippleAccountTests()
     testRippleAddressCreate();
     testRippleAddressEqual();
     testRippleAddressUnknown();
+    testRippleAddressUnknownStrict();
     testRippleAddressInvalid();
     testRippleAddressFee();
 }
@@ -922,7 +929,7 @@ static void submitWithDestinationTag() {
     const char * source_paper_key = "use a valid account here";
     BRRippleAccount sourceAccount = rippleAccountCreate(source_paper_key);
     // Carl's Coinbase account and destination tag.
-    BRRippleAddress targetAddress = rippleAddressCreateFromString("rw2ciyaNshpHe7bCHo4bRWq6pqqynnWKQg");
+    BRRippleAddress targetAddress = rippleAddressCreateFromString("rw2ciyaNshpHe7bCHo4bRWq6pqqynnWKQg", true);
     assembleTransaction(source_paper_key, sourceAccount, targetAddress, 400000, 3, 2611653455);
     rippleAccountFree(sourceAccount);
 }
@@ -931,8 +938,8 @@ static void submitWithoutDestinationTag() {
     // Create an account so we can get a public key
     const char * source_paper_key = "use a valid account here";
     BRRippleAccount sourceAccount = rippleAccountCreate(source_paper_key);
-    // Carl's Coinbase account and destination tag.
-    BRRippleAddress targetAddress = rippleAddressCreateFromString("rpFRjDTUmUdVgMjwurx3osy4rNmXsoz7FE");
+    // Carl's Coinbase account and destination tag. (Using 'false' on a valid address is okay).
+    BRRippleAddress targetAddress = rippleAddressCreateFromString("rpFRjDTUmUdVgMjwurx3osy4rNmXsoz7FE", false);
     assembleTransaction(source_paper_key, sourceAccount, targetAddress, 300000, 4, 0);
     rippleAccountFree(sourceAccount);
 }


### PR DESCRIPTION
The 'strict' argument if true, will demand that address strings be an 'r...' XRP address.  If false, then "unknown" and "__error__" are processed.  The User interface uses strict of true; the BlockSet interface used strict of false - so that transfers can be processed properly.