### PR TITLE
CORE-852: Address Compiler Warnings.

### DIFF
--- a/WalletKitCore/bitcoin/BRPeerManager.c
+++ b/WalletKitCore/bitcoin/BRPeerManager.c
@@ -1545,7 +1545,7 @@ BRPeerManager *BRPeerManagerNew(const BRChainParams *params, BRWallet *wallet, u
     }
 
     _peer_log("BPM: checkpoint found with %u last block height",
-              (manager->lastBlock ? manager->lastBlock->height : -1));
+              (manager->lastBlock ? manager->lastBlock->height : (uint32_t) -1));
 
     block = NULL;
     

--- a/WalletKitCore/bitcoin/BRWalletManager.c
+++ b/WalletKitCore/bitcoin/BRWalletManager.c
@@ -2056,7 +2056,7 @@ bwmHandleAnnounceBlockNumber (BRWalletManager manager,
     pthread_mutex_lock (&manager->lock);
     BRSyncManagerAnnounceGetBlockNumber (manager->syncManager,
                                          rid,
-                                         (int32_t) blockNumber);
+                                         blockNumber);
     pthread_mutex_unlock (&manager->lock);
     return 1;
 }

--- a/WalletKitCore/crypto/BRCryptoAmount.c
+++ b/WalletKitCore/crypto/BRCryptoAmount.c
@@ -85,7 +85,7 @@ extern BRCryptoAmount
 cryptoAmountCreateInteger (int64_t value,
                            BRCryptoUnit unit) {
 
-    UInt256 v = uint256Create (value < 0 ? -value : value);
+    UInt256 v = uint256Create ((uint64_t) (value < 0 ? -value : value));
     return cryptoAmountCreateUInt256 (v, (value < 0 ? CRYPTO_TRUE : CRYPTO_FALSE), unit);
 }
 
@@ -256,7 +256,7 @@ cryptoAmountGetDouble (BRCryptoAmount amount,
     assert (NULL != overflow);
     long double power  = powl (10.0, cryptoUnitGetBaseDecimalOffset(unit));
     long double result = uint256CoerceDouble (amount->value, (int*) overflow) / power;
-    return (CRYPTO_TRUE == amount->isNegative ? -result : result);
+    return (double) (CRYPTO_TRUE == amount->isNegative ? -result : result);
 }
 
 extern uint64_t

--- a/WalletKitCore/crypto/BRCryptoFeeBasis.c
+++ b/WalletKitCore/crypto/BRCryptoFeeBasis.c
@@ -126,7 +126,7 @@ cryptoFeeBasisGetFee (BRCryptoFeeBasis feeBasis) {
             double fee = (((double) feeBasis->u.btc.feePerKB) * feeBasis->u.btc.sizeInByte) / 1000.0;
             return cryptoAmountCreateInternal (feeBasis->unit,
                                                CRYPTO_FALSE,
-                                               uint256Create (round (fee)),
+                                               uint256Create ((uint64_t) lround (fee)),
                                                1);
         }
             

--- a/WalletKitCore/crypto/BRCryptoHash.c
+++ b/WalletKitCore/crypto/BRCryptoHash.c
@@ -108,12 +108,12 @@ extern int
 cryptoHashGetHashValue (BRCryptoHash hash) {
     switch (hash->type) {
         case BLOCK_CHAIN_TYPE_BTC:
-            return hash->u.btc.u32[0];
+            return (int) hash->u.btc.u32[0];
 
         case BLOCK_CHAIN_TYPE_ETH:
             return ethHashSetValue (&hash->u.eth);
 
         case BLOCK_CHAIN_TYPE_GEN:
-            return genericHashSetValue (hash->u.gen);
+            return (int) genericHashSetValue (hash->u.gen);
     }
 }

--- a/WalletKitCore/crypto/BRCryptoKey.c
+++ b/WalletKitCore/crypto/BRCryptoKey.c
@@ -71,7 +71,7 @@ cryptoKeyRelease (BRCryptoKey key) {
 
 extern BRCryptoBoolean
 cryptoKeyIsProtectedPrivate (const char *privateKey) {
-    return BRBIP38KeyIsValid (privateKey);
+    return AS_CRYPTO_BOOLEAN (BRBIP38KeyIsValid (privateKey));
 }
 
 private_extern BRCryptoKey
@@ -211,7 +211,7 @@ cryptoKeyCreateForBIP32BitID (const char *phrase, int index, const char *uri,  c
     BRBIP39DeriveKey (seed.u8, phrase, NULL);
 
     BRKey core;
-    BRBIP32BitIDKey (&core, &seed, sizeof(UInt512), index, uri);
+    BRBIP32BitIDKey (&core, &seed, sizeof(UInt512), (uint32_t) index, uri);
 
     BRCryptoKey result = cryptoKeyCreateInternal(core, CRYPTO_ADDRESS_PARAMS);
 

--- a/WalletKitCore/crypto/BRCryptoPayment.c
+++ b/WalletKitCore/crypto/BRCryptoPayment.c
@@ -450,7 +450,8 @@ cryptoPaymentProtocolRequestGetPrimaryTargetAddress (BRCryptoPaymentProtocolRequ
                 char *addressString = malloc (addressSize);
                 BRTxOutputAddress (output, addressString, addressSize, chainParams->addrParams);
 
-                address = cryptoAddressCreateAsBTC (BRAddressFill (chainParams->addrParams, addressString), isBTC);
+                address = cryptoAddressCreateAsBTC (BRAddressFill (chainParams->addrParams, addressString),
+                                                    AS_CRYPTO_BOOLEAN (isBTC));
                 free (addressString);
             }
             break;

--- a/WalletKitCore/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/crypto/BRCryptoWallet.c
@@ -507,7 +507,7 @@ cryptoWalletValidateTransferAttribute (BRCryptoWallet wallet,
             BRGenericTransferAttribute genAttribute =
             genTransferAttributeCreate (cryptoTransferAttributeGetKey(attribute),
                                         cryptoTransferAttributeGetValue(attribute),
-                                        cryptoTransferAttributeIsRequired(attribute));
+                                        CRYPTO_TRUE == cryptoTransferAttributeIsRequired(attribute));
 
             *validates = genWalletValidateTransferAttribute(wallet->u.gen, genAttribute);
             genTransferAttributeRelease (genAttribute);
@@ -547,9 +547,9 @@ cryptoWalletValidateTransferAttributes (BRCryptoWallet wallet,
             for (size_t index = 0; index < attributesCount; index++) {
                 BRCryptoTransferAttribute attribute = attributes[index];
                 BRGenericTransferAttribute genAttribute =
-                genTransferAttributeCreate(cryptoTransferAttributeGetKey(attribute),
-                                         cryptoTransferAttributeGetValue(attribute),
-                                         cryptoTransferAttributeIsRequired(attribute));
+                genTransferAttributeCreate (cryptoTransferAttributeGetKey(attribute),
+                                            cryptoTransferAttributeGetValue(attribute),
+                                            CRYPTO_TRUE == cryptoTransferAttributeIsRequired(attribute));
                 array_add (genAttributes, genAttribute);
             }
 
@@ -733,9 +733,9 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
                     // (by the caller) and we only extract info.
                     BRCryptoTransferAttribute attribute = attributes[index];
                     BRGenericTransferAttribute genAttribute =
-                    genTransferAttributeCreate(cryptoTransferAttributeGetKey(attribute),
-                                             cryptoTransferAttributeGetValue(attribute),
-                                             cryptoTransferAttributeIsRequired(attribute));
+                    genTransferAttributeCreate (cryptoTransferAttributeGetKey(attribute),
+                                                cryptoTransferAttributeGetValue(attribute),
+                                                CRYPTO_TRUE == cryptoTransferAttributeIsRequired(attribute));
                     array_add (genAttributes, genAttribute);
                 }
                 tid = genWalletCreateTransferWithAttributes (wid, genAddr, genValue, genFeeBasis, genAttributes);

--- a/WalletKitCore/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/crypto/BRCryptoWalletManager.c
@@ -472,7 +472,7 @@ cryptoWalletManagerSetNetworkReachable (BRCryptoWalletManager cwm,
                                         BRCryptoBoolean isNetworkReachable) {
     switch (cwm->type) {
         case BLOCK_CHAIN_TYPE_BTC:
-            BRWalletManagerSetNetworkReachable (cwm->u.btc, isNetworkReachable);
+            BRWalletManagerSetNetworkReachable (cwm->u.btc, CRYPTO_TRUE == isNetworkReachable);
             break;
         default:
             break;

--- a/WalletKitCore/crypto/BRCryptoWalletManagerClient.c
+++ b/WalletKitCore/crypto/BRCryptoWalletManagerClient.c
@@ -350,7 +350,7 @@ cwmWalletEventAsBTC (BRWalletManagerClientContext context,
             assert (NULL != wallet);
 
             // Get the amount (it is 'taken')
-            BRCryptoAmount amount = cryptoAmountCreateInteger (event.u.balance.satoshi, unit); // taken
+            BRCryptoAmount amount = cryptoAmountCreateInteger ((int64_t) event.u.balance.satoshi, unit); // taken
 
             // Generate BALANCE_UPDATED with 'amount' (taken)
             cwm->listener.walletEventCallback (cwm->listener.context,
@@ -2120,12 +2120,12 @@ cwmAnnounceGetTransactionsComplete (OwnershipKept BRCryptoWalletManager cwm,
     if (CWM_CALLBACK_TYPE_BTC_GET_TRANSACTIONS == callbackState->type && BLOCK_CHAIN_TYPE_BTC == cwm->type) {
         bwmAnnounceTransactionComplete (cwm->u.btc,
                                         callbackState->rid,
-                                        success);
+                                        CRYPTO_TRUE == success);
 
     } else if (CWM_CALLBACK_TYPE_ETH_GET_TRANSACTIONS == callbackState->type && BLOCK_CHAIN_TYPE_ETH == cwm->type) {
         ewmAnnounceTransactionComplete (cwm->u.eth,
                                         callbackState->rid,
-                                        AS_ETHEREUM_BOOLEAN (success));
+                                        AS_ETHEREUM_BOOLEAN (CRYPTO_TRUE == success));
 
     } else if (CWM_CALLBACK_TYPE_GEN_GET_TRANSACTIONS == callbackState->type && BLOCK_CHAIN_TYPE_GEN== cwm->type) {
         genManagerAnnounceTransferComplete (cwm->u.gen,

--- a/WalletKitCore/ethereum/base/BREthereumAddress.h
+++ b/WalletKitCore/ethereum/base/BREthereumAddress.h
@@ -102,7 +102,7 @@ ethAddressEqual (BREthereumAddress address1,
 
 static inline int
 ethAddressHashValue (BREthereumAddress address) {
-    return ((UInt160 *) &address)->u32[0];
+    return (int) ((UInt160 *) &address)->u32[0];
 }
 
 static inline int

--- a/WalletKitCore/ethereum/base/BREthereumEther.c
+++ b/WalletKitCore/ethereum/base/BREthereumEther.c
@@ -80,7 +80,7 @@ ethEtherCreateZero(void) {
 
 extern BREthereumEther
 ethEtherCreateString(const char *number, BREthereumEtherUnit unit, BRCoreParseStatus *status) {
-    int decimals = 3 * unit;
+    int decimals = 3 * (int) unit;
     
     UInt256 value = uint256CreateParseDecimal(number, decimals, status);
     return ethEtherCreate(value);
@@ -101,7 +101,7 @@ ethEtherGetValue(const BREthereumEther ether,
 
 extern char * // Perhaps can be done. 1 WEI -> 1e-18 Ether
 ethEtherGetValueString(const BREthereumEther ether, BREthereumEtherUnit unit) {
-    return uint256CoerceStringDecimal(ether.valueInWEI, 3 * unit);
+    return uint256CoerceStringDecimal(ether.valueInWEI, 3 * (int) unit);
 }
 
 extern BRRlpItem

--- a/WalletKitCore/ethereum/base/BREthereumHash.c
+++ b/WalletKitCore/ethereum/base/BREthereumHash.c
@@ -130,6 +130,6 @@ ethHashesIndex (BRArrayOf(BREthereumHash) hashes,
                 BREthereumHash hash) {
     for (size_t index = 0; index < array_count(hashes); index++)
         if (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (hash, hashes[index])))
-            return index;
+            return (ssize_t) index;
     return -1;
 }

--- a/WalletKitCore/ethereum/base/BREthereumHash.h
+++ b/WalletKitCore/ethereum/base/BREthereumHash.h
@@ -100,7 +100,7 @@ ethHashEncodeList (BRArrayOf(BREthereumHash) hashes, BRRlpCoder coder);
 // BRSet Support
 inline static int
 ethHashSetValue (const BREthereumHash *hash) {
-    return ((UInt256 *) hash->bytes)->u32[0];
+    return (int) ((UInt256 *) hash->bytes)->u32[0];
 }
 
 // BRSet Support

--- a/WalletKitCore/ethereum/bcs/BREthereumBCS.c
+++ b/WalletKitCore/ethereum/bcs/BREthereumBCS.c
@@ -1424,7 +1424,7 @@ bcsHandleAccountState (BREthereumBCS bcs,
     // Ensure we have a Block
     BREthereumBlock block = BRSetGet(bcs->blocks, &blockHash);
     if (NULL == block) {
-        eth_log ("BCS", "Block %" PRIu64 " Missed (Account)", (NULL == block ? -1 : blockGetNumber(block)));
+        eth_log ("BCS", "Block %" PRIu64 " Missed (Account)", (NULL == block ? UINT64_MAX : blockGetNumber(block)));
         return;
     }
 
@@ -1495,7 +1495,7 @@ bcsHandleBlockBody (BREthereumBCS bcs,
     // Ensure we have a Block
     BREthereumBlock block = BRSetGet(bcs->blocks, &blockHash);
     if (NULL == block) {
-        eth_log ("BCS", "Block %" PRIu64 " Missed (Bodies)", (NULL == block ? -1 : blockGetNumber(block)));
+        eth_log ("BCS", "Block %" PRIu64 " Missed (Bodies)", (NULL == block ? UINT64_MAX : blockGetNumber(block)));
         bcsReleaseOmmersAndTransactionsFully(bcs, transactions, ommers);
         return;
     }
@@ -1531,13 +1531,13 @@ bcsHandleBlockBody (BREthereumBCS bcs,
     BREthereumTransaction *neededTransactions = NULL;
 
     // Check the transactions one-by-one.
-    for (int i = 0; i < array_count(transactions); i++) {
+    for (size_t i = 0; i < array_count(transactions); i++) {
         BREthereumTransaction tx = transactions[i];
         assert (NULL != tx);
         
         // If it is our transaction (as source or target), handle it.
         if (ETHEREUM_BOOLEAN_IS_TRUE(transactionHasAddress(tx, bcs->address))) {
-            eth_log("BCS", "Bodies %" PRIu64 " Found Transaction at %d",
+            eth_log("BCS", "Bodies %" PRIu64 " Found Transaction at %zu",
                     blockGetNumber(block), i);
 
             // We'll need a copy of the transaction as the orginal transaction is held in `block`
@@ -1720,7 +1720,7 @@ bcsHandleTransactionReceipts (BREthereumBCS bcs,
     // Ensure we have a Block
     BREthereumBlock block = BRSetGet(bcs->blocks, &blockHash);
     if (NULL == block) {
-        eth_log ("BCS", "Block %" PRIu64 " Missed (Receipts)", (NULL == block ? -1 : blockGetNumber(block)));
+        eth_log ("BCS", "Block %" PRIu64 " Missed (Receipts)", (NULL == block ? UINT64_MAX : blockGetNumber(block)));
         bcsReleaseReceiptsFully(bcs, receipts);
         return;
     }

--- a/WalletKitCore/ethereum/bcs/BREthereumBCSSync.c
+++ b/WalletKitCore/ethereum/bcs/BREthereumBCSSync.c
@@ -875,7 +875,7 @@ computeOptimalStep (uint64_t numberOfBlocks,
                     uint64_t *optimalCount) {
     *optimalCount = 0;
     uint64_t optimalRemainder = UINT64_MAX;
-    for (int count = SYNC_N_ARY_REQUEST_MINIMUM; count < SYNC_N_ARY_REQUEST_MAXIMUM; count++) {
+    for (size_t count = SYNC_N_ARY_REQUEST_MINIMUM; count < SYNC_N_ARY_REQUEST_MAXIMUM; count++) {
         uint64_t remainder = numberOfBlocks % count;
         if (remainder <= optimalRemainder) {
             optimalRemainder = remainder;

--- a/WalletKitCore/ethereum/contract/BREthereumContract.c
+++ b/WalletKitCore/ethereum/contract/BREthereumContract.c
@@ -396,7 +396,7 @@ ethContractEncode (BREthereumContract contract, BREthereumContractFunction funct
 //
 static void
 encodeReverseBytes (uint8_t *t, const uint8_t *s, size_t slen) {
-    for (int i = 0; i < slen; i++)
+    for (size_t i = 0; i < slen; i++)
         t[slen - i - 1] = s[i];
 }
 

--- a/WalletKitCore/ethereum/contract/BREthereumToken.c
+++ b/WalletKitCore/ethereum/contract/BREthereumToken.c
@@ -96,7 +96,7 @@ ethTokenGetDescription(BREthereumToken token) {
     return token->description;
 }
 
-extern int
+extern unsigned int
 ethTokenGetDecimals(BREthereumToken token) {
     return token->decimals;
 }
@@ -127,7 +127,7 @@ ethTokenCreate (const char *address,
                 const char *symbol,
                 const char *name,
                 const char *description,
-                int decimals,
+                unsigned int decimals,
                 BREthereumGas defaultGasLimit,
                 BREthereumGasPrice defaultGasPrice) {
     BREthereumToken token = malloc (sizeof(struct BREthereumTokenRecord));
@@ -158,7 +158,7 @@ ethTokenUpdate (BREthereumToken token,
                 const char *symbol,
                 const char *name,
                 const char *description,
-                int decimals,
+                unsigned int decimals,
                 BREthereumGas defaultGasLimit,
                 BREthereumGasPrice defaultGasPrice) {
 

--- a/WalletKitCore/ethereum/contract/BREthereumToken.h
+++ b/WalletKitCore/ethereum/contract/BREthereumToken.h
@@ -53,7 +53,7 @@ ethTokenGetName (BREthereumToken token);
 extern const char *
 ethTokenGetDescription(BREthereumToken token);
 
-extern int
+extern unsigned int
 ethTokenGetDecimals (BREthereumToken token);
 
 extern BREthereumGas
@@ -73,7 +73,7 @@ ethTokenCreate (const char *address,
                 const char *symbol,
                 const char *name,
                 const char *description,
-                int decimals,
+                unsigned int decimals,
                 BREthereumGas defaultGasLimit,
                 BREthereumGasPrice defaultGasPrice);
 
@@ -85,7 +85,7 @@ ethTokenUpdate (BREthereumToken token,
                 const char *symbol,
                 const char *name,
                 const char *description,
-                int decimals,
+                unsigned int decimals,
                 BREthereumGas defaultGasLimit,
                 BREthereumGasPrice defaultGasPrice);
 

--- a/WalletKitCore/ethereum/ewm/BREthereumEWM.c
+++ b/WalletKitCore/ethereum/ewm/BREthereumEWM.c
@@ -2823,7 +2823,7 @@ ewmCreateToken (BREthereumEWM ewm,
                 const char *symbol,
                 const char *name,
                 const char *description,
-                int decimals,
+                unsigned int decimals,
                 BREthereumGas defaultGasLimit,
                 BREthereumGasPrice defaultGasPrice) {
     if (NULL == address || 0 == strlen(address)) return NULL;

--- a/WalletKitCore/ethereum/ewm/BREthereumEWM.h
+++ b/WalletKitCore/ethereum/ewm/BREthereumEWM.h
@@ -470,7 +470,7 @@ ewmCreateToken (BREthereumEWM ewm,
                 const char *symbol,
                 const char *name,
                 const char *description,
-                int decimals,
+                unsigned int decimals,
                 BREthereumGas defaultGasLimit,
                 BREthereumGasPrice defaultGasPrice);
 

--- a/WalletKitCore/ethereum/ewm/BREthereumWallet.c
+++ b/WalletKitCore/ethereum/ewm/BREthereumWallet.c
@@ -480,7 +480,7 @@ walletWalkTransfers (BREthereumWallet wallet,
                      void *context,
                      BREthereumTransferPredicate predicate,
                      BREthereumTransferWalker walker) {
-    for (int i = 0; i < array_count(wallet->transfers); i++)
+    for (unsigned int i = 0; i < array_count(wallet->transfers); i++)
         if (predicate (context, wallet->transfers[i], i))
             walker (context, wallet->transfers[i], i);
 }

--- a/WalletKitCore/ethereum/les/msg/BREthereumMessageDIS.c
+++ b/WalletKitCore/ethereum/les/msg/BREthereumMessageDIS.c
@@ -242,7 +242,7 @@ messageDISPingCreate (BREthereumDISEndpoint to,
 static BRRlpItem
 messageDISPingEncode (BREthereumDISMessagePing message, BREthereumMessageCoder coder) {
     return rlpEncodeList (coder.rlp, 4,
-                          rlpEncodeUInt64 (coder.rlp, message.version, 1),
+                          rlpEncodeUInt64 (coder.rlp, (uint64_t) message.version, 1),
                           endpointDISEncode (&message.from, coder.rlp),
                           endpointDISEncode (&message.to, coder.rlp),
                           rlpEncodeUInt64 (coder.rlp, message.expiration, 1));

--- a/WalletKitCore/ethereum/les/msg/BREthereumMessageLES.h
+++ b/WalletKitCore/ethereum/les/msg/BREthereumMessageLES.h
@@ -476,7 +476,8 @@ messageLESGetCredits (const BREthereumLESMessage *message);
 extern uint64_t
 messageLESGetCreditsCount (const BREthereumLESMessage *message);
 
-#define LES_MESSAGE_NO_REQUEST_ID    (-1)
+#define LES_MESSAGE_NO_REQUEST_ID    ((uint64_t) -1)
+
 extern size_t
 messageLESGetRequestId (const BREthereumLESMessage *message);
 

--- a/WalletKitCore/ethereum/les/msg/BREthereumMessagePIP.h
+++ b/WalletKitCore/ethereum/les/msg/BREthereumMessagePIP.h
@@ -294,7 +294,7 @@ messagePIPGetCredits (const BREthereumPIPMessage *message);
 extern uint64_t
 messagePIPGetCreditsCount (const BREthereumPIPMessage *message);
 
-#define PIP_MESSAGE_NO_REQUEST_ID    (-1)
+#define PIP_MESSAGE_NO_REQUEST_ID    ((uint64_t) -1)
 extern size_t
 messagePIPGetRequestId (const BREthereumPIPMessage *message);
 

--- a/WalletKitCore/ethereum/rlp/BRRlpCoder.c
+++ b/WalletKitCore/ethereum/rlp/BRRlpCoder.c
@@ -286,11 +286,11 @@ rlpCoderHasFailed (BRRlpCoder coder) {
 /**
  * Return the index of the first non-zero byte; if all bytes are zero, bytesCount is returned
  */
-static int
+static size_t
 findNonZeroIndex (uint8_t *bytes, size_t bytesCount) {
-    for (int i = 0; i < bytesCount; i++)
+    for (size_t i = 0; i < bytesCount; i++)
         if (bytes[i] != 0) return i;
-    return (int) bytesCount;
+    return bytesCount;
 }
 
 /**
@@ -301,7 +301,7 @@ findNonZeroIndex (uint8_t *bytes, size_t bytesCount) {
 static void
 swapBytesIfLittleEndian (uint8_t *target, uint8_t *source, size_t count) {
     assert (target != source);  // common overlap case, but wholely insufficient.
-    for (int i = 0; i < count; i++) {
+    for (size_t i = 0; i < count; i++) {
 #if BYTE_ORDER == LITTLE_ENDIAN
         target[i] = source[count - 1 - i];
 #else

--- a/WalletKitCore/ethereum/util/BRUtilMath.c
+++ b/WalletKitCore/ethereum/util/BRUtilMath.c
@@ -32,7 +32,7 @@ uint256CreateDouble (double value, int decimals, int *overflow) {
     y = roundl(y);  // (extraneous) Axe any fraction; can't participate in a UInt
 
     for (size_t index = 0; index < 4; index++)
-        result.u64[index] = UINT64_MAX * modfl(y/UINT64_MAX, &y);
+        result.u64[index] = UINT64_MAX * (uint64_t) modfl(y/UINT64_MAX, &y);
     *overflow = (y != 0);
 
     return *overflow ? UINT256_ZERO : result;
@@ -149,16 +149,16 @@ uint256Mul (const UInt256 x, const UInt256 y) {
     //  assert (__LITTLE_ENDIAN__ == BYTE_ORDER);
     UInt512 z = UINT512_ZERO;
     
-    unsigned int count = sizeof (UInt256) / sizeof(uint32_t);
+    size_t count = sizeof (UInt256) / sizeof(uint32_t);
     
     // Use 'grade school' long multiplication in base 32.  For UInt256 we'll have 8 32-bit value
     // and perform 64 32-bit multiplications.  A more sophisticated algorith, e.g. Katasuba, can
     // perform just 27 32-bit multiplications.  For our application, not a big enough savings for
     // the added complexity.
-    for (int xi = 0; xi < count; xi++) {
+    for (size_t xi = 0; xi < count; xi++) {
         uint64_t carry = 0;
         if (x.u32[xi] == 0) continue;
-        for (int yi = 0; yi < count; yi++) {
+        for (size_t yi = 0; yi < count; yi++) {
             uint64_t total = z.u32[yi + xi] + carry + AS_UINT64 (y.u32[yi]) * AS_UINT64 (x.u32[xi]);
             carry = total >> 32;
             z.u32[yi + xi] = (uint32_t) total;
@@ -206,7 +206,7 @@ uint256Mul_Double (UInt256 x, double y, int *overflow, int *negative, double *re
     uint64_t overflows[count];  // overflow can be huge... not large enough...
 
     // From high to low, account for underflow along the way...
-    for (int i = count -1; i >= 0; i--) {
+    for (ssize_t i = count - 1; i >= 0; i--) {
         long double total = y * (long double) (x.u16[i]) + underflow;
         // split out the integer and fractional parts
         fractional = modfl (total, &integer);

--- a/WalletKitCore/ethereum/util/BRUtilMathParse.c
+++ b/WalletKitCore/ethereum/util/BRUtilMathParse.c
@@ -90,10 +90,10 @@ uint256CreateParseDecimal (const char *string, int decimals, BRCoreParseStatus *
     if (NULL == whole) whole = "";
     if (NULL == fract) fract = "";
     
-    unsigned long fractLen = strlen(fract);
+   size_t fractLen = strlen(fract);
     
     // Strip trailing '0'
-    for (int i = 0; i < fractLen; i++) {
+    for (size_t i = 0; i < fractLen; i++) {
         if ('0' == fract[fractLen - 1 - i])
             fract[fractLen - 1 - i] = '\0';
         else
@@ -138,7 +138,7 @@ uint256CreateParseDecimal (const char *string, int decimals, BRCoreParseStatus *
 //    16
 
 // The maximum digits allowed in a string so as to prevent overflow in uint64_t
-static int
+static size_t
 parseMaximumDigitsForUInt64InBase (int base) {
     switch (base) {
         case 2:  return 64;
@@ -148,7 +148,7 @@ parseMaximumDigitsForUInt64InBase (int base) {
     }
 }
 
-static int
+static size_t
 parseMaximumDigitsForUInt256InBase (int base) {
     switch (base) {
         case 2:  return 256;
@@ -161,7 +161,7 @@ parseMaximumDigitsForUInt256InBase (int base) {
 // Compute (expt base power)
 static UInt256
 parseUInt256Power (int base, int power, int *overflow) {
-    int maxPower = parseMaximumDigitsForUInt64InBase(base);
+    size_t maxPower = parseMaximumDigitsForUInt64InBase(base);
     
     if (power > maxPower) {
         *overflow = 1;
@@ -170,7 +170,7 @@ parseUInt256Power (int base, int power, int *overflow) {
     
     uint64_t value = 1;
     while (power-- > 0)
-        value *= base;  // slow, but yeah.
+        value *= (uint64_t) base;  // slow, but yeah.
     
     // Reality is that this can overflow for 16^16 = 2^64 (one too many).  We'll handle it.
     //  Probably also for 2^256... can't handle that one similarly.
@@ -194,7 +194,7 @@ parseUInt256ScaleByPower (UInt256 value, int base, int power, int *overflow) {
 
 static UInt256
 parseUInt64 (const char *string, int digits, int base) {
-    int maxDigits = parseMaximumDigitsForUInt64InBase(base);
+    size_t maxDigits = parseMaximumDigitsForUInt64InBase(base);
     assert (digits <= maxDigits );
     
     //
@@ -246,8 +246,8 @@ uint256CreateParse (const char *string, int base, BRCoreParseStatus *status) {
     if (CORE_PARSE_OK != *status)
         return UINT256_ZERO;
 
-    int maxDigits = parseMaximumDigitsForUInt256InBase(base);
-    long length = strlen (string);
+    size_t maxDigits = parseMaximumDigitsForUInt256InBase(base);
+    size_t length = strlen (string);
     
     if (length > maxDigits) {  // overflow
         *status = CORE_PARSE_OVERFLOW;
@@ -255,7 +255,7 @@ uint256CreateParse (const char *string, int base, BRCoreParseStatus *status) {
     }
     
     // We'll process this many digits in `string`.
-    int stringChunks = parseMaximumDigitsForUInt64InBase(base);
+    size_t stringChunks = parseMaximumDigitsForUInt64InBase(base);
 
     // Fill this in.
     UInt256 value = UINT256_ZERO;
@@ -263,7 +263,7 @@ uint256CreateParse (const char *string, int base, BRCoreParseStatus *status) {
     // For parsing a string like "123.45", the character at index 0 is '1'.  So by parsing chunks
     // with ascending index, we naturally treat `string` as big endian - no matter the base.
     // Eventually, when `parseUInt64()` calls `strtoull` we'll still be using big endian.
-    for (long index = 0; index < length; index += stringChunks) {
+    for (size_t index = 0; index < length; index += stringChunks) {
         // On the first time through, get an initial value
         if (index == 0) {
             value = parseUInt64(string, stringChunks, base);
@@ -301,9 +301,9 @@ uint256CreateParse (const char *string, int base, BRCoreParseStatus *status) {
 //
 static char *
 coerceReverseString (const char *s) {
-    long len = strlen(s);
+    size_t len = strlen(s);
     char *t = calloc (1 + len, 1);
-    for (int i = 0; i < len; i++)
+    for (size_t i = 0; i < len; i++)
         t[len - i - 1] = s[i];
     return t;
 }
@@ -325,7 +325,7 @@ uint256CoerceString (UInt256 x, int base) {
         case 16: {
             // Reverse and 'strip zeros'
             UInt256 xr = UInt256Reverse(x);  // TODO: LITTLE ENDIAN only
-            int xrIndex = 0;
+            size_t xrIndex = 0;
             // We explicitly handled the '0 == x' case up-front.  Thus xr.u8 *always*
             // eventually has a non-zero value.
             while (0 == xr.u8[xrIndex]) xrIndex++;

--- a/WalletKitCore/generic/BRGenericManager.c
+++ b/WalletKitCore/generic/BRGenericManager.c
@@ -72,7 +72,7 @@ struct BRGenericManagerRecord {
     /**
      * An identiifer for a BRD Request
      */
-    unsigned int requestId;
+    int requestId;
 
     /**
      * An EventHandler for Main.  All 'announcements' (via PeerManager (or BRD) hit here.
@@ -820,7 +820,7 @@ genTransferAttributesEncode (OwnershipKept BRArrayOf(BRGenericTransferAttribute)
         items[index] = rlpEncodeList (coder, 3,
                                       rlpEncodeString (coder, key),
                                       rlpEncodeString (coder, (NULL == val ? "" : val)),
-                                      rlpEncodeUInt64 (coder, isRequired, 1));
+                                      rlpEncodeUInt64 (coder, (uint64_t) isRequired, 1));
     }
     return rlpEncodeListItems(coder, items, itemsCount);
 }

--- a/WalletKitCore/hedera/BRHederaAccount.c
+++ b/WalletKitCore/hedera/BRHederaAccount.c
@@ -48,7 +48,9 @@ hederaAccountCreateWithSerialization (uint8_t *bytes, size_t bytesCount)
     memcpy(&shard, addressBytes, 8);
     memcpy(&realm, addressBytes + 8, 8);
     memcpy(&accountNum, addressBytes + 16, 8);
-    account->address = hederaAddressCreate(ntohll(shard), ntohll(realm), ntohll(accountNum));
+    account->address = hederaAddressCreate ((BRHederaAddressComponentType) ntohll(shard),
+                                            (BRHederaAddressComponentType) ntohll(realm),
+                                            (BRHederaAddressComponentType) ntohll(accountNum));
 
     // Now copy the public key
     memcpy(account->publicKey, bytes + HEDERA_ADDRESS_SERIALIZED_SIZE, HEDERA_PUBLIC_KEY_SIZE);

--- a/WalletKitCore/hedera/BRHederaAddress.c
+++ b/WalletKitCore/hedera/BRHederaAddress.c
@@ -53,7 +53,7 @@ extern char * hederaAddressAsString (BRHederaAddress address)
         // Hedera addresses are shown as a.b.c
         char buffer[1024];
         memset(buffer, 0x00, sizeof(buffer));
-        size_t stringSize = sprintf(buffer, "%" PRIu64 ".%" PRIu64  ".%" PRIu64, address->shard, address->realm, address->account);
+        size_t stringSize = (size_t) sprintf(buffer, "%" PRIi64 ".%" PRIi64  ".%" PRIi64, address->shard, address->realm, address->account);
         assert(stringSize > 0);
         string = calloc(1, stringSize + 1);
         strcpy(string, buffer);
@@ -67,7 +67,7 @@ static bool hederaStringIsValid (const char * input)
     int64_t shard = -1;
     int64_t realm = -1;
     int64_t account = -1;
-    sscanf(input, "%" PRIu64 ".%" PRIu64  ".%" PRIu64, &shard, &realm, &account);
+    sscanf(input, "%" PRIi64 ".%" PRIi64  ".%" PRIi64, &shard, &realm, &account);
     if (shard >= 0 && realm >= 0 && account >= 0) {
         return true;
     }
@@ -82,7 +82,7 @@ BRHederaAddress hederaAddressStringToAddress(const char* input)
 
     // Hedera address are shard.realm.account
     BRHederaAddress address = (BRHederaAddress) calloc(1, sizeof(struct BRHederaAddressRecord));
-    sscanf(input, "%" PRIu64 ".%" PRIu64  ".%" PRIu64,
+    sscanf(input, "%" PRIi64 ".%" PRIi64  ".%" PRIi64,
            &address->shard, &address->realm, &address->account);
     return address;
 }
@@ -169,9 +169,9 @@ void hederaAddressSerialize(BRHederaAddress address, uint8_t * buffer, size_t si
 
     // The Hedera account IDs are made up of 3 int64_t numbers
     // Get the account id values convert to network order
-    BRHederaAddressComponentType shard = htonll(hederaAddressGetShard(address));
-    BRHederaAddressComponentType realm = htonll(hederaAddressGetRealm(address));
-    BRHederaAddressComponentType account = htonll(hederaAddressGetAccount(address));
+    BRHederaAddressComponentType shard   = (BRHederaAddressComponentType) htonll(hederaAddressGetShard(address));
+    BRHederaAddressComponentType realm   = (BRHederaAddressComponentType) htonll(hederaAddressGetRealm(address));
+    BRHederaAddressComponentType account = (BRHederaAddressComponentType) htonll(hederaAddressGetAccount(address));
 
     // Copy the values to the buffer
     size_t componentSize = sizeof (BRHederaAddressComponentType);

--- a/WalletKitCore/hedera/BRHederaAddress.c
+++ b/WalletKitCore/hedera/BRHederaAddress.c
@@ -20,9 +20,9 @@
 #include <stdbool.h>
 
 struct BRHederaAddressRecord {
-    int64_t shard;
-    int64_t realm;
-    int64_t account;
+    BRHederaAddressComponentType shard;
+    BRHederaAddressComponentType realm;
+    BRHederaAddressComponentType account;
 };
 
 extern void hederaAddressFree (BRHederaAddress address)
@@ -53,7 +53,7 @@ extern char * hederaAddressAsString (BRHederaAddress address)
         // Hedera addresses are shown as a.b.c
         char buffer[1024];
         memset(buffer, 0x00, sizeof(buffer));
-        size_t stringSize = sprintf(buffer, "%" PRIi64 ".%" PRIi64  ".%" PRIi64, address->shard, address->realm, address->account);
+        size_t stringSize = sprintf(buffer, "%" PRIu64 ".%" PRIu64  ".%" PRIu64, address->shard, address->realm, address->account);
         assert(stringSize > 0);
         string = calloc(1, stringSize + 1);
         strcpy(string, buffer);
@@ -67,7 +67,7 @@ static bool hederaStringIsValid (const char * input)
     int64_t shard = -1;
     int64_t realm = -1;
     int64_t account = -1;
-    sscanf(input, "%" PRIi64 ".%" PRIi64  ".%" PRIi64, &shard, &realm, &account);
+    sscanf(input, "%" PRIu64 ".%" PRIu64  ".%" PRIu64, &shard, &realm, &account);
     if (shard >= 0 && realm >= 0 && account >= 0) {
         return true;
     }
@@ -82,7 +82,7 @@ BRHederaAddress hederaAddressStringToAddress(const char* input)
 
     // Hedera address are shard.realm.account
     BRHederaAddress address = (BRHederaAddress) calloc(1, sizeof(struct BRHederaAddressRecord));
-    sscanf(input, "%" PRIi64 ".%" PRIi64  ".%" PRIi64,
+    sscanf(input, "%" PRIu64 ".%" PRIu64  ".%" PRIu64,
            &address->shard, &address->realm, &address->account);
     return address;
 }
@@ -145,19 +145,19 @@ extern BRHederaAddress hederaAddressClone (BRHederaAddress address)
     return NULL;
 }
 
-int64_t hederaAddressGetShard (BRHederaAddress address)
+BRHederaAddressComponentType hederaAddressGetShard (BRHederaAddress address)
 {
     assert (address);
     return address->shard;
 }
 
-int64_t hederaAddressGetRealm (BRHederaAddress address)
+BRHederaAddressComponentType hederaAddressGetRealm (BRHederaAddress address)
 {
     assert (address);
     return address->realm;
 }
 
-int64_t hederaAddressGetAccount (BRHederaAddress address)
+BRHederaAddressComponentType hederaAddressGetAccount (BRHederaAddress address)
 {
     assert (address);
     return address->account;
@@ -169,13 +169,15 @@ void hederaAddressSerialize(BRHederaAddress address, uint8_t * buffer, size_t si
 
     // The Hedera account IDs are made up of 3 int64_t numbers
     // Get the account id values convert to network order
-    int64_t shard = htonll(hederaAddressGetShard(address));
-    int64_t realm = htonll(hederaAddressGetRealm(address));
-    int64_t account = htonll(hederaAddressGetAccount(address));
+    BRHederaAddressComponentType shard = htonll(hederaAddressGetShard(address));
+    BRHederaAddressComponentType realm = htonll(hederaAddressGetRealm(address));
+    BRHederaAddressComponentType account = htonll(hederaAddressGetAccount(address));
 
     // Copy the values to the buffer
-    memcpy(buffer, &shard, sizeof(int64_t));
-    memcpy(buffer + sizeof(int64_t), &realm, sizeof(int64_t));
-    memcpy(buffer + (2 * sizeof(int64_t)), &account, sizeof(int64_t));
+    size_t componentSize = sizeof (BRHederaAddressComponentType);
+
+    memcpy(buffer, &shard, componentSize);
+    memcpy(buffer + componentSize, &realm, componentSize);
+    memcpy(buffer + (2 * componentSize), &account, componentSize);
 }
 

--- a/WalletKitCore/hedera/BRHederaAddress.h
+++ b/WalletKitCore/hedera/BRHederaAddress.h
@@ -64,7 +64,7 @@ hederaAddressFree (BRHederaAddress address);
 extern int
 hederaAddressIsFeeAddress (BRHederaAddress address);
 
-typedef uint64_t BRHederaAddressComponentType;
+typedef int64_t BRHederaAddressComponentType;
 
 /**
  * Get the Hedera address field values

--- a/WalletKitCore/hedera/BRHederaAddress.h
+++ b/WalletKitCore/hedera/BRHederaAddress.h
@@ -64,6 +64,8 @@ hederaAddressFree (BRHederaAddress address);
 extern int
 hederaAddressIsFeeAddress (BRHederaAddress address);
 
+typedef uint64_t BRHederaAddressComponentType;
+
 /**
  * Get the Hedera address field values
  *
@@ -71,9 +73,9 @@ hederaAddressIsFeeAddress (BRHederaAddress address);
  *
  * @return int64_t value
  */
-int64_t hederaAddressGetShard (BRHederaAddress address);
-int64_t hederaAddressGetRealm (BRHederaAddress address);
-int64_t hederaAddressGetAccount (BRHederaAddress address);
+BRHederaAddressComponentType hederaAddressGetShard (BRHederaAddress address);
+BRHederaAddressComponentType hederaAddressGetRealm (BRHederaAddress address);
+BRHederaAddressComponentType hederaAddressGetAccount (BRHederaAddress address);
 
 /**
  * Copy a BRHederaAddress

--- a/WalletKitCore/hedera/BRHederaBase.h
+++ b/WalletKitCore/hedera/BRHederaBase.h
@@ -21,11 +21,11 @@ extern "C" {
 #endif
 
 // Declare public/shared items
-typedef int64_t BRHederaUnitTinyBar;
+typedef uint64_t BRHederaUnitTinyBar;
 
 typedef struct __hedera_timestamp {
-    int64_t seconds; // Number of complete seconds since the start of the epoch
-    int32_t nano; // Number of nanoseconds since the start of the last second
+    uint64_t seconds; // Number of complete seconds since the start of the epoch
+    uint32_t nano; // Number of nanoseconds since the start of the last second
 } BRHederaTimeStamp;
 
 typedef struct {

--- a/WalletKitCore/hedera/BRHederaBase.h
+++ b/WalletKitCore/hedera/BRHederaBase.h
@@ -21,11 +21,11 @@ extern "C" {
 #endif
 
 // Declare public/shared items
-typedef uint64_t BRHederaUnitTinyBar;
+typedef int64_t BRHederaUnitTinyBar;
 
 typedef struct __hedera_timestamp {
-    uint64_t seconds; // Number of complete seconds since the start of the epoch
-    uint32_t nano; // Number of nanoseconds since the start of the last second
+    int64_t seconds; // Number of complete seconds since the start of the epoch
+    int32_t nano; // Number of nanoseconds since the start of the last second
 } BRHederaTimeStamp;
 
 typedef struct {

--- a/WalletKitCore/hedera/BRHederaTransaction.c
+++ b/WalletKitCore/hedera/BRHederaTransaction.c
@@ -90,7 +90,7 @@ extern BRHederaTransaction hederaTransactionCreate (BRHederaAddress source,
     } else {
         // It would great to be able to get the timestamp from the txID - but I guess
         // we just have to use whatever came from blockset
-        transaction->timeStamp.seconds = timestamp;
+        transaction->timeStamp.seconds = (int64_t) timestamp;
     }
 
     transaction->hash = hash;

--- a/WalletKitCore/hedera/BRHederaWallet.c
+++ b/WalletKitCore/hedera/BRHederaWallet.c
@@ -40,7 +40,7 @@ hederaWalletCreate (BRHederaAccount account)
      "0.0.15":"35.236.2.27:50211"}
      */
     array_new(wallet->nodes, HEDERA_NODE_COUNT);
-    int64_t hedera_node_start = HEDERA_NODE_START;
+    // int64_t hedera_node_start = HEDERA_NODE_START;
     for (int i = HEDERA_NODE_START; i < (HEDERA_NODE_COUNT + HEDERA_NODE_START); i++) {
         array_add(wallet->nodes, hederaAddressCreate(0, 0, i));
     }

--- a/WalletKitCore/ripple/BRRippleBase58.c
+++ b/WalletKitCore/ripple/BRRippleBase58.c
@@ -50,7 +50,7 @@ int rippleDecodeBase58(const char* input, uint8_t *output)
     memset(&inv[0], -1, sizeof(inv));
     int map_num = 0;
     for (int i = 0; i < strlen(rippleAlphabet); i++) {
-        inv[rippleAlphabet[i]] = map_num++;
+        inv[(int) rippleAlphabet[i]] = map_num++;
     }
     
     const char *psz = input;
@@ -58,7 +58,7 @@ int rippleDecodeBase58(const char* input, uint8_t *output)
     
     // Skip and count leading zeroes
     int zeroes = 0;
-    while (remain > 0 && inv[*psz] == 0)
+    while (remain > 0 && inv[(int) *psz] == 0)
     {
         ++zeroes;
         ++psz;
@@ -79,7 +79,7 @@ int rippleDecodeBase58(const char* input, uint8_t *output)
     // Do the decoding
     while (remain > 0)
     {
-        int carry = inv[*psz];
+        int carry = inv[(int) *psz];
         if (carry == -1)
             return 0;
         // Apply "b256 = b256 * 58 + carry".

--- a/WalletKitCore/ripple/BRRipplePrivateStructs.h
+++ b/WalletKitCore/ripple/BRRipplePrivateStructs.h
@@ -62,7 +62,7 @@ inline static VLBytes * createVLBytes(int length)
 {
     VLBytes * bytes = calloc(1, sizeof(VLBytes));
     bytes->length = length;
-    bytes->value = calloc(1, length);
+    bytes->value = calloc(1, (size_t) length);
     return bytes;
 }
 

--- a/WalletKitCore/support/BRBase58.c
+++ b/WalletKitCore/support/BRBase58.c
@@ -199,12 +199,12 @@ size_t BRBase58DecodeEx(uint8_t* data, size_t dataLen, const char *str, const ch
     memset(&reverseLookup[0], -1, sizeof(reverseLookup));
     int map_num = 0;
     for (int i = 0; i < strlen(alphabet); i++) {
-        reverseLookup[alphabet[i]] = map_num++;
+        reverseLookup[(int) alphabet[i]] = map_num++;
     }
 
     // Skip and count leading zeroes
-    int zcount = 0;
-    while (str && reverseLookup[*str] == 0) str++, zcount++;
+    size_t zcount = 0;
+    while (str && reverseLookup[(int) *str] == 0) str++, zcount++;
 
     // Create buffer large enough to hold the decode bytes
     int bufSize = (str) ? (int)(strlen(str)*733/1000 + 1) : 0;
@@ -214,7 +214,7 @@ size_t BRBase58DecodeEx(uint8_t* data, size_t dataLen, const char *str, const ch
     // Do the decoding
     while (str && *str)
     {
-        int carry = reverseLookup[*str];
+        int carry = reverseLookup[(int) *str];
         if (carry == -1) return 0;
 
         for (int i = bufSize - 1; i >= 0; i--)
@@ -227,7 +227,7 @@ size_t BRBase58DecodeEx(uint8_t* data, size_t dataLen, const char *str, const ch
     }
 
     // Skip leading zeros in buf
-    int i = 0;
+    size_t i = 0;
     while(buf[i] == 0) { i++; }
 
     // Calculate the length


### PR DESCRIPTION
Working through compiler warnings.  Should be no functional changes.

Numerous changes for:

- `int` ==> `size_t`
- `int` ==> `BRCRyptoBoolean` (using `CRYPTO_TRUE ==` and `AS_CRYPTO_BOOLEAN`)
- `int` ==> `unsigned int` (be more explicit)
- `-1` ==> 'sentinel' to an explicit type.

Addressed some XRP and HBAR issues.  Note change to  `BRHederaUnitTinyBar`.

Many warnings remain (in 'bitcoin/' and 'ethereum/'.
