### PR TITLE
CORE-868: Explicitly set the Hedera account to 'uninitialized'

### DIFF
--- a/WalletKitCore/hedera/BRHederaAccount.c
+++ b/WalletKitCore/hedera/BRHederaAccount.c
@@ -28,9 +28,8 @@ extern BRHederaAccount hederaAccountCreateWithSeed (UInt512 seed)
     // From the secret get the public key
     hederaKeyGetPublicKey(privateKey, account->publicKey);
 
-    // We cannot generate an address from the public key - but
-    // when running the demo app we need to put in some address
-    // account->address = hederaAddressCreateFromString("0.0.3229");
+    // The address is uninitialized.
+    account->address = hederaAddressCreate (0, 0, 0);
 
     return account;
 }
@@ -48,6 +47,8 @@ hederaAccountCreateWithSerialization (uint8_t *bytes, size_t bytesCount)
     memcpy(&shard, addressBytes, 8);
     memcpy(&realm, addressBytes + 8, 8);
     memcpy(&accountNum, addressBytes + 16, 8);
+
+    // This may be uninitialized
     account->address = hederaAddressCreate ((BRHederaAddressComponentType) ntohll(shard),
                                             (BRHederaAddressComponentType) ntohll(realm),
                                             (BRHederaAddressComponentType) ntohll(accountNum));
@@ -92,11 +93,8 @@ hederaAccountGetPublicKeyBytes (BRHederaAccount account, size_t *bytesCount) {
 extern BRHederaAddress hederaAccountGetAddress (BRHederaAccount account)
 {
     assert(account);
-    if (account->address) {
-        return hederaAddressClone (account->address);
-    } else {
-        return NULL;
-    }
+    assert(account->address);
+    return hederaAddressClone (account->address);
 }
 
 extern BRHederaAddress hederaAccountGetPrimaryAddress (BRHederaAccount account)
@@ -105,19 +103,18 @@ extern BRHederaAddress hederaAccountGetPrimaryAddress (BRHederaAccount account)
 }
 
 extern int hederaAccountHasPrimaryAddress (BRHederaAccount account) {
-    return NULL != account->address;
+    return !hederaAddressIsUninitializedAddress (account->address);
 }
 
 extern uint8_t *hederaAccountGetSerialization (BRHederaAccount account, size_t *bytesCount) {
     assert (NULL != bytesCount);
     assert (NULL != account);
+    assert (NULL != account->address);
 
     // Get the sizes of what we are storing and allocate storage
     uint8_t addressBuffer[HEDERA_ADDRESS_SERIALIZED_SIZE] = {0};
-    // If we have an address then serialize it - otherwise we just copy 0's to the stream
-    if (NULL != account->address) {
-        hederaAddressSerialize (account->address, addressBuffer, HEDERA_ADDRESS_SERIALIZED_SIZE);
-    }
+    hederaAddressSerialize (account->address, addressBuffer, HEDERA_ADDRESS_SERIALIZED_SIZE);
+
     *bytesCount = HEDERA_ADDRESS_SERIALIZED_SIZE + HEDERA_PUBLIC_KEY_SIZE;
     uint8_t *bytes = calloc (1, *bytesCount);
 

--- a/WalletKitCore/hedera/BRHederaAccount.c
+++ b/WalletKitCore/hedera/BRHederaAccount.c
@@ -61,14 +61,15 @@ hederaAccountCreateWithSerialization (uint8_t *bytes, size_t bytesCount)
 
 extern void hederaAccountFree (BRHederaAccount account)
 {
-    assert(account);
-    if (account->address) hederaAddressFree (account->address);
+    assert(account && account->address);
+    hederaAddressFree (account->address);
     free(account);
 }
 
 extern void hederaAccountSetAddress (BRHederaAccount account, BRHederaAddress address)
 {
     assert(account);
+    assert(address);
     account->address = hederaAddressClone (address);
 }
 

--- a/WalletKitCore/hedera/BRHederaAddress.c
+++ b/WalletKitCore/hedera/BRHederaAddress.c
@@ -19,6 +19,7 @@
 #include <memory.h>
 #include <stdbool.h>
 
+// An 'uninitialized address' has {shard, realm, account} as {0, 0, 0}
 struct BRHederaAddressRecord {
     BRHederaAddressComponentType shard;
     BRHederaAddressComponentType realm;
@@ -157,6 +158,11 @@ hederaAddressIsFeeAddress (BRHederaAddress address)
     } else {
         return 0;
     }
+}
+
+extern int
+hederaAddressIsUninitializedAddress (BRHederaAddress address) {
+    return 0 == address->shard && 0 == address->realm && 0 == address->account;
 }
 
 extern BRHederaAddress hederaAddressClone (BRHederaAddress address)

--- a/WalletKitCore/hedera/BRHederaAddress.h
+++ b/WalletKitCore/hedera/BRHederaAddress.h
@@ -65,6 +65,9 @@ hederaAddressFree (BRHederaAddress address);
 extern int
 hederaAddressIsFeeAddress (BRHederaAddress address);
 
+extern int
+hederaAddressIsUninitializedAddress (BRHederaAddress address);
+
 typedef int64_t BRHederaAddressComponentType;
 
 /**

--- a/WalletKitCoreTests/test/hedera/testHedera.c
+++ b/WalletKitCoreTests/test/hedera/testHedera.c
@@ -312,7 +312,10 @@ static void hederaAccountCheckSerialize(const char * userName)
     UInt512 seed = UINT512_ZERO;
     BRBIP39DeriveKey(seed.u8, accountInfo.paper_key, NULL); // no passphrase
     BRHederaAccount account = hederaAccountCreateWithSeed(seed);
+    assert (hederaAddressIsUninitializedAddress (hederaAccountGetPrimaryAddress(account)));
     BRHederaAddress address = hederaAddressCreateFromString(accountInfo.account_string, true);
+    if (0 == strcmp(userName, "none"))
+        assert (hederaAddressIsUninitializedAddress(address));
     BRKey key1 = hederaAccountGetPublicKey(account);
     hederaAccountSetAddress(account, address);
     size_t accountByteSize = 0;
@@ -543,6 +546,7 @@ static void account_tests() {
     hederaAccountCheckPublicKey("choose");
 
     hederaAccountCheckSerialize("patient");
+    hederaAccountCheckSerialize("none");
 
     accountStringTest("patient");
 }


### PR DESCRIPTION
Always ensure that `account->address` is not NULL.

Extended the unit test with the 'none' account.  Confirmed that serialize/deserialize of 'none' (with an uninitialized address) remains consistent.